### PR TITLE
Fix Helm chart indentation

### DIFF
--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -112,7 +112,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "gcore-webhook.fullname" . }}:flowcontrol-solver
   labels:
-  {{ include "gcore-webhook.labels" . | indent 4 }}
+{{ include "gcore-webhook.labels" . | indent 4 }}
 rules:
   - apiGroups:
       - "flowcontrol.apiserver.k8s.io"
@@ -128,7 +128,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "gcore-webhook.fullname" . }}:flowcontrol-solver
   labels:
-  {{ include "gcore-webhook.labels" . | indent 4 }}
+{{ include "gcore-webhook.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
The flowcontrol-solver ClusterRole and ClusterRoleBinding had an extra
level of indentation for labels which resulted in invalid YAML after
templating. This patch removes the extra indentation so Helm install
works again.