### PR TITLE
ICM-43718: [docker] upgrade golang version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS build_deps
+FROM golang:1.24-alpine AS build_deps
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
Push and build fail because version is different between go.mod and dockerfile.